### PR TITLE
NHSU CR-302 MIS BLOCKER EMAIL VALIDATOR OF ENTIRE EHCS

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Schemata.MixProject do
     [
       {:jason, "~> 1.3"},
       {:json_xema, "~> 0.6.1", optional: true},
-      {:nex_json_schema, "~> 0.8.6"}
+      {:nex_json_schema2, "~> 0.8.7"}
     ]
   end
 end


### PR DESCRIPTION
Greetings TWIMC!

On behalf of Ukrainian State Enterprise "Elektronne Zdorovya" I want to inform you can EMAIL validator presented in this package is used in [@edenlablcc/schemata](http://github.com/edenlabllc/schemata) EHCS dependency in core application. The CR-302 ticket is a blocker for Ukrainian Medical Information Systems to register email that has gTLD more that 3 letters which is not only violation of RFC 822 but also naive and improper.

The problem is that EHCS is built up based on HEX.PM dependency in `schemata`:

```
 {:nex_json_schema, "~> 0.8.6"}
 ```
 
 You either should accept the following change:
 
 ```
 - @email_regex ~r<^[\w!#$%&'*+/=?`{|}~^-]+(?:\.[\w!#$%&'*+/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}$>i
 + @email_regex ~r<^[\w!#$%&'*+/=?`{|}~^-]+(?:\.[\w!#$%&'*+/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,63}$>i
 ```
 
 in `lib/ex_json_schema/validator/format.ex`.
 
But overall the `https://hex.pm/packages/nex_json_schema` packages should be replaced with 
 `https://hex.pm/packages/nex_json_schema2` that hosts on NHSU Github. The duplicated message as separate merge will be requested at `edenlabllc/schemata` repository:
 
 ```
 - {:nex_json_schema, "~> 0.8.6"}
 + {:nex_json_schema2, "~> 0.8.7"}
 ```